### PR TITLE
Update aurelia-cookie.d.ts

### DIFF
--- a/dist/aurelia-cookie.d.ts
+++ b/dist/aurelia-cookie.d.ts
@@ -1,30 +1,29 @@
-export declare class Cookie {
-  
-  /**
-       *
-       * Get a cookie by its name
-       */
-  static get(name?: any): any;
-  
-  /**
-       * Set a cookie
-       */
-  static set(name?: any, value?: any, options?: any): any;
-  
-  /**
-       * Deletes a cookie by setting its expiry date in the past
-       */
-  static delete(name?: any, domain?: any): any;
-  
-  /**
-       * Get all set cookies and return an array
-       */
-  static all(): any;
-  static parse(str?: any): any;
-  static encode(value?: any): any;
-  static decode(value?: any): any;
+declare module 'aurelia-cookie' {
+    export class Cookie {
+      /**
+           *
+           * Get a cookie by its name
+           */
+      static get(name?: any): any;
+      
+      /**
+           * Set a cookie
+           */
+      static set(name?: any, value?: any, options?: any): any;
+      
+      /**
+           * Deletes a cookie by setting its expiry date in the past
+           */
+      static delete(name?: any, domain?: any): any;
+      
+      /**
+           * Get all set cookies and return an array
+           */
+      static all(): any;
+      static parse(str?: any): any;
+      static encode(value?: any): any;
+      static decode(value?: any): any;
+    }
+    
+    export function configure(aurelia?: any): any;
 }
-export declare function configure(aurelia?: any): any;
-export declare {
-  Cookie
-};


### PR DESCRIPTION
Updated to Aurelia 1.0. Your plugin updated from 1.0.4 to 1.0.8 and stuff broke for me. Couldn't install/find your definition file via `typings install`, copied it from here and it didn't work for me out of the box. These few changes fixed my compilation error. See for yourself if you want to integrate it. At least it fixes it for me.