### PR TITLE
adds path parameter to delete

### DIFF
--- a/dist/amd/aurelia-cookie.d.ts
+++ b/dist/amd/aurelia-cookie.d.ts
@@ -18,7 +18,7 @@ export declare class AureliaCookie {
     /**
     * Deletes a cookie by setting its expiry date in the past
     */
-    static delete(name: string, domain?: null): void;
+    static delete(name: string, domain?: string, path?: string): void;
     /**
     * Get all set cookies and return an array
     */

--- a/dist/amd/aurelia-cookie.js
+++ b/dist/amd/aurelia-cookie.js
@@ -47,11 +47,13 @@ define(["require", "exports"], function (require, exports) {
         /**
         * Deletes a cookie by setting its expiry date in the past
         */
-        AureliaCookie.delete = function (name, domain) {
-            if (domain === void 0) { domain = null; }
+        AureliaCookie.delete = function (name, domain, path) {
             var cookieString = name + " =;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
             if (domain) {
                 cookieString += "; domain=" + domain;
+            }
+            if (path) {
+                cookieString += "; path=" + path;
             }
             document.cookie = cookieString;
         };

--- a/dist/commonjs/aurelia-cookie.d.ts
+++ b/dist/commonjs/aurelia-cookie.d.ts
@@ -18,7 +18,7 @@ export declare class AureliaCookie {
     /**
     * Deletes a cookie by setting its expiry date in the past
     */
-    static delete(name: string, domain?: null): void;
+    static delete(name: string, domain?: string, path?: string): void;
     /**
     * Get all set cookies and return an array
     */

--- a/dist/commonjs/aurelia-cookie.js
+++ b/dist/commonjs/aurelia-cookie.js
@@ -46,11 +46,13 @@ var AureliaCookie = (function () {
     /**
     * Deletes a cookie by setting its expiry date in the past
     */
-    AureliaCookie.delete = function (name, domain) {
-        if (domain === void 0) { domain = null; }
+    AureliaCookie.delete = function (name, domain, path) {
         var cookieString = name + " =;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
         if (domain) {
             cookieString += "; domain=" + domain;
+        }
+        if (path) {
+            cookieString += "; path=" + path;
         }
         document.cookie = cookieString;
     };

--- a/dist/es2015/aurelia-cookie.d.ts
+++ b/dist/es2015/aurelia-cookie.d.ts
@@ -18,7 +18,7 @@ export declare class AureliaCookie {
     /**
     * Deletes a cookie by setting its expiry date in the past
     */
-    static delete(name: string, domain?: null): void;
+    static delete(name: string, domain?: string, path?: string): void;
     /**
     * Get all set cookies and return an array
     */

--- a/dist/es2015/aurelia-cookie.js
+++ b/dist/es2015/aurelia-cookie.js
@@ -45,11 +45,13 @@ var AureliaCookie = (function () {
     /**
     * Deletes a cookie by setting its expiry date in the past
     */
-    AureliaCookie.delete = function (name, domain) {
-        if (domain === void 0) { domain = null; }
+    AureliaCookie.delete = function (name, domain, path) {
         var cookieString = name + " =;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
         if (domain) {
             cookieString += "; domain=" + domain;
+        }
+        if (path) {
+            cookieString += "; path=" + path;
         }
         document.cookie = cookieString;
     };

--- a/dist/system/aurelia-cookie.d.ts
+++ b/dist/system/aurelia-cookie.d.ts
@@ -18,7 +18,7 @@ export declare class AureliaCookie {
     /**
     * Deletes a cookie by setting its expiry date in the past
     */
-    static delete(name: string, domain?: null): void;
+    static delete(name: string, domain?: string, path?: string): void;
     /**
     * Get all set cookies and return an array
     */

--- a/dist/system/aurelia-cookie.js
+++ b/dist/system/aurelia-cookie.js
@@ -52,11 +52,13 @@ System.register([], function (exports_1, context_1) {
                 /**
                 * Deletes a cookie by setting its expiry date in the past
                 */
-                AureliaCookie.delete = function (name, domain) {
-                    if (domain === void 0) { domain = null; }
+                AureliaCookie.delete = function (name, domain, path) {
                     var cookieString = name + " =;expires=Thu, 01 Jan 1970 00:00:01 GMT;";
                     if (domain) {
                         cookieString += "; domain=" + domain;
+                    }
+                    if (path) {
+                        cookieString += "; path=" + path;
                     }
                     document.cookie = cookieString;
                 };

--- a/src/aurelia-cookie.ts
+++ b/src/aurelia-cookie.ts
@@ -63,11 +63,15 @@ export class AureliaCookie {
     /**
     * Deletes a cookie by setting its expiry date in the past
     */
-    static delete(name: string, domain = null) {
+    static delete(name: string, domain?: string, path?: string) {
         let cookieString = `${name} =;expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
 
         if (domain) {
             cookieString += `; domain=${domain}`;
+        }
+
+        if (path) {
+            cookieString += `; path=${path}`;
         }
 
         document.cookie = cookieString;


### PR DESCRIPTION
Cookies added a path can never be deleted with the current version since you can't specify a path when deleting. This should fix that. Also fixes the parameters types in `delete`.