### PR TITLE
Adds the SameSite directive

### DIFF
--- a/src/aurelia-cookie.ts
+++ b/src/aurelia-cookie.ts
@@ -4,6 +4,7 @@ export interface OptionsInterface {
     path?: string;
     domain?: string;
     secure?: boolean;
+    sameSite?: string;
 }
 
 export class AureliaCookie {
@@ -20,7 +21,7 @@ export class AureliaCookie {
 
         return null;
     }
-    
+
     /**
     * Set a cookie
     */
@@ -30,7 +31,7 @@ export class AureliaCookie {
         if (value === null) {
             options.expiry = -1;
         }
-        
+
         /**
         * Expiry date in hours
         */
@@ -57,9 +58,13 @@ export class AureliaCookie {
             str += '; secure';
         }
 
+        if (options.sameSite) {
+            str += `; samesite=${options.sameSite}`;
+        }
+
         document.cookie = str;
     }
-    
+
     /**
     * Deletes a cookie by setting its expiry date in the past
     */
@@ -76,7 +81,7 @@ export class AureliaCookie {
 
         document.cookie = cookieString;
     }
-    
+
     /**
     * Get all set cookies and return an array
     */


### PR DESCRIPTION
As described in the [`Set-Cookie` MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie), `SameSite` is an available directive, and one that will eventually will dramatically [change the behavior of cookies on Chrome](https://www.chromestatus.com/feature/5088147346030592).

This PR adds the `sameSite` option used to set the `SameSite` directive on `Cookie.set()`.